### PR TITLE
Bump upper bound on ilist

### DIFF
--- a/hsimport.cabal
+++ b/hsimport.cabal
@@ -53,7 +53,7 @@ library
     , directory         >=1.2.0.1  && <1.4
     , dyre              ^>=0.8
     , haskell-src-exts  >=1.18.0   && <1.24
-    , ilist             >=0.1      && <0.4
+    , ilist             >=0.1      && <0.5
     , microlens         ^>=0.4
     , mtl               >=2.1.2    && <2.3
     , split             ^>=0.2.2


### PR DESCRIPTION
This fixes the broken build of hsimport in nixpkgs.